### PR TITLE
Update requests requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.22.0
+requests>=2.22.0
 pytest==4.6.2

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
     ],
     packages=["sleeper_wrapper"],
     include_package_data=True,
-    install_requires=["requests==2.22.0", "pytest==4.6.2"]
+    install_requires=["requests>=2.22.0", "pytest==4.6.2"]
 )


### PR DESCRIPTION
Updating the `requests` requirement to be ">=2.22.0" instead of "=2.22.0" in order to avoid `urllib3` vulnerability outlined [here](https://github.com/advisories/GHSA-q2q7-5pp4-w6pg). After changing the files, I installed the package locally and was able to successfully run the following functions:
- `user.get_user()`
- `user.get_all_leagues("nfl", 2021)
- `league.get_matchups(1)`
- `league.get_users()`

I did not change the package version in `setup.py`, but that could be folded in easily if you think it should be.